### PR TITLE
Add Subtasks Functionality to Task Management

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -30,6 +30,18 @@ class TaskController extends Controller {
         return new CreatedResponse($task);
     }
 
+    public function storeSubtask(int $id, TaskRequest $request): CreatedResponse {
+        $task = $this->service->storeSubtask($id, $request->validated());
+
+        return new CreatedResponse($task);
+    }
+
+    public function getAllSubtasks(int $id): SuccessResponse {
+        $subtasks = $this->service->getAllSubtasks($id);
+
+        return new SuccessResponse($subtasks);
+    }
+
     public function update(int $id, TaskRequest $request): SuccessResponse {
         $task = $this->service->update($id, $request->validated());
 

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class Task extends Model
 {
@@ -15,4 +16,12 @@ class Task extends Model
         'priority',
         'due_date'
     ];
+
+    public function subtasks(): BelongsToMany {
+        return $this->belongsToMany(Task::class, 'subtasks_relation', 'main_task_id', 'sub_task_id');
+    }
+
+    public function mainTask(): BelongsToMany {
+        return $this->belongsToMany(Task::class, 'subtasks_relation', 'sub_task_id', 'main_task_id');
+    }
 }

--- a/app/Services/TaskService.php
+++ b/app/Services/TaskService.php
@@ -22,6 +22,21 @@ class TaskService {
         return new TaskResource($this->repository->store($data));
     }
 
+    public function storeSubtask(int $id, mixed $data): TaskResource {
+        $mainTask = $this->repository->show($id);
+        $subTask = $this->repository->store($data);
+
+        $mainTask->subtasks()->attach($subTask->id);
+
+        return new TaskResource($subTask);
+    }
+
+    public function getAllSubtasks(int $id): AnonymousResourceCollection {
+        $task = $this->repository->show($id);
+
+        return TaskResource::collection($task->subtasks);
+    }
+
     public function update($id, $data): TaskResource {
         return new TaskResource($this->repository->update($id, $data));
     }

--- a/database/migrations/2025_02_17_123922_create_subtasks_relation_table.php
+++ b/database/migrations/2025_02_17_123922_create_subtasks_relation_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('subtasks_relation', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('main_task_id');
+            $table->unsignedBigInteger('sub_task_id');
+            $table->timestamps();
+
+            $table->foreign('main_task_id')->references('id')->on('tasks')->onDelete('cascade');
+            $table->foreign('sub_task_id')->references('id')->on('tasks')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('subtasks_relation');
+    }
+};

--- a/routes/task.php
+++ b/routes/task.php
@@ -8,7 +8,9 @@ use Illuminate\Support\Facades\Route;
 Route::prefix('/tasks')->group(function () {
     Route::get('/', [TaskController::class, 'index']);
     Route::get('/{id}', [TaskController::class, 'show']);
+    Route::get('/{id}/subtasks', [TaskController::class, 'getAllSubtasks']);
     Route::put('/{id}', [TaskController::class, 'update']);
     Route::delete('/{id}', [TaskController::class, 'destroy']);
     Route::post('/', [TaskController::class, 'store']);
+    Route::post('/{id}/subtasks', [TaskController::class, 'storeSubtask']);
 });


### PR DESCRIPTION
### **PR Description**
This PR introduces the ability to manage subtasks within tasks, allowing users to create and retrieve subtasks for a given task. Key changes include:

#### **Changes**
1. **Subtask Relationship**:
   - Added a many-to-many relationship between tasks to support subtasks.
   - Created a pivot table `subtasks_relation` to store the relationship between main tasks and subtasks.

2. **New Methods**:
   - Added `storeSubtask` to create a subtask for a given task.
   - Added `getAllSubtasks` to retrieve all subtasks for a specific task.

3. **Controller Updates**:
   - Added new routes for subtask management:
     - `POST /tasks/{id}/subtasks` to create a subtask.
     - `GET /tasks/{id}/subtasks` to retrieve all subtasks.

4. **Service Layer**:
   - Implemented logic to handle subtask creation and retrieval in the `TaskService`.

5. **Database Migration**:
   - Added a new migration to create the `subtasks_relation` table.

#### **New Files**
- `database/migrations/2025_02_17_123922_create_subtasks_relation_table.php`

#### **Modified Files**
- `app/Http/Controllers/TaskController.php`
- `app/Models/Task.php`
- `app/Services/TaskService.php`
- `routes/task.php`

#### **Testing**
- Verify that subtasks can be created for a task using the `POST /tasks/{id}/subtasks` endpoint.
- Ensure that all subtasks for a task can be retrieved using the `GET /tasks/{id}/subtasks` endpoint.
- Test edge cases (e.g., invalid task IDs, empty subtask lists).